### PR TITLE
Added goldenDirSpecWithEncoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Test [bs-aeson](https://github.com/plow-technologies/bs-aeson) serialization aga
 
 ## Changes
 
+### 4.4.0
+* Added goldenDirSpecWithEncoding which takes an encoding from the following set 
+```
+  [ `hex 
+  | `utf8
+  | `ascii
+  | `latin1
+  | `base64
+  | `ucs2
+  | `binary
+  | `utf16le ]
+```
+
 ### 4.3.0
 
 * Update bs-aeson to 4.7.0.

--- a/__tests__/Aeson_spec_test.ml
+++ b/__tests__/Aeson_spec_test.ml
@@ -144,6 +144,12 @@ let () =
 
   AesonSpec.goldenDirSpec Test.decodeShape Test.encodeShape "shape" "__tests__/golden/Shape";
 
+  AesonSpec.goldenDirSpecWithEncoding Test.decodePerson Test.encodePerson "person" "__tests__/golden/Person" `latin1;
+
+  AesonSpec.goldenDirSpecWithEncoding Test.decodeCompany Test.encodeCompany "company" "__tests__/golden/Company" `latin1;
+
+  AesonSpec.goldenDirSpecWithEncoding Test.decodeShape Test.encodeShape "shape" "__tests__/golden/Shape" `latin1;
+
   (* these two tests should fail *)
   (* AesonSpec.goldenDirSpec Test.decodePerson Test.brokenEncodePerson "person" "__tests__/golden/Person";
    * 

--- a/lib/js/__tests__/Aeson_spec_test.js
+++ b/lib/js/__tests__/Aeson_spec_test.js
@@ -463,6 +463,12 @@ AesonSpec.goldenDirSpec(decodeCompany, encodeCompany, "company", "__tests__/gold
 
 AesonSpec.goldenDirSpec(decodeShape, encodeShape, "shape", "__tests__/golden/Shape");
 
+AesonSpec.goldenDirSpecWithEncoding(decodePerson, encodePerson, "person", "__tests__/golden/Person", "latin1");
+
+AesonSpec.goldenDirSpecWithEncoding(decodeCompany, encodeCompany, "company", "__tests__/golden/Company", "latin1");
+
+AesonSpec.goldenDirSpecWithEncoding(decodeShape, encodeShape, "shape", "__tests__/golden/Shape", "latin1");
+
 AesonSpec_Jest.describe("isJsonFile", (function (param) {
         AesonSpec_Jest.test("", (function (param) {
                 var files = Fs.readdirSync("__tests__/golden/Person");

--- a/lib/js/src/AesonSpec.js
+++ b/lib/js/src/AesonSpec.js
@@ -163,12 +163,32 @@ function goldenSpec(decode, encode, name_of_type, json_file) {
 }
 
 function sampleGoldenSpec(decode, encode, name_of_type, json_file) {
-  AesonSpec_Jest.describe("AesonSpec.sampleGoldenSpec: " + (name_of_type + (" from file '" + (json_file + "'"))), (function (param) {
+  AesonSpec_Jest.describe("AesonSpec.sampleGoldenSpec: " + (name_of_type + (" from file '" + (json_file + "' with encoding utf8"))), (function (param) {
           var json = JSON.parse(Fs.readFileSync(json_file, "utf8"));
           AesonSpec_Jest.test("decode then encode json_file", (function (param) {
                   return sampleJsonRoundtripSpec(decode, encode, json);
                 }));
         }));
+}
+
+function encodingToString(encoding) {
+  if (encoding === "utf8") {
+    return "utf8";
+  } else if (encoding === "base64") {
+    return "base64";
+  } else if (encoding === "latin1") {
+    return "latin1";
+  } else if (encoding === "binary") {
+    return "binary";
+  } else if (encoding === "hex") {
+    return "hex";
+  } else if (encoding === "ascii") {
+    return "ascii";
+  } else if (encoding === "utf16le") {
+    return "utf16le";
+  } else {
+    return "ucs2";
+  }
 }
 
 function isJsonFile(fileName) {
@@ -189,6 +209,19 @@ function goldenDirSpec(decode, encode, name_of_type, json_dir) {
         }), files_in_dir);
 }
 
+function goldenDirSpecWithEncoding(decode, encode, name_of_type, json_dir, encoding) {
+  var files_in_dir = Js_array.filter(isJsonFile, Fs.readdirSync(json_dir));
+  $$Array.iter((function (json_file) {
+          var json_file$1 = json_dir + ("/" + json_file);
+          AesonSpec_Jest.describe("AesonSpec.sampleGoldenSpec: " + (name_of_type + (" from file '" + (json_file$1 + ("' with encoding " + encodingToString(encoding))))), (function (param) {
+                  var json = JSON.parse(Fs.readFileSync(json_file$1, encoding));
+                  AesonSpec_Jest.test("decode then encode json_file", (function (param) {
+                          return sampleJsonRoundtripSpec(decode, encode, json);
+                        }));
+                }));
+        }), files_in_dir);
+}
+
 function decodeIntWithResult(json) {
   return Aeson_decode.wrapResult(Aeson_decode.$$int, json);
 }
@@ -203,5 +236,6 @@ exports.goldenSpec = goldenSpec;
 exports.sampleGoldenSpec = sampleGoldenSpec;
 exports.isJsonFile = isJsonFile;
 exports.goldenDirSpec = goldenDirSpec;
+exports.goldenDirSpecWithEncoding = goldenDirSpecWithEncoding;
 exports.decodeIntWithResult = decodeIntWithResult;
 /* fs Not a pure module */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-aeson-spec",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Test bs-aeson encode and decode functions against golden files generated from the Haskell library hspec-golden-aeson",
   "main": "index.js",
   "scripts": {

--- a/src/AesonSpec.mli
+++ b/src/AesonSpec.mli
@@ -43,6 +43,8 @@ val isJsonFile : string -> bool
 
 val goldenDirSpec : (Js_json.t -> ('a, string) Belt.Result.t) -> ('a -> Js_json.t) -> string -> string -> unit
 
+val goldenDirSpecWithEncoding : (Js_json.t -> ('a, string) Belt.Result.t) -> ('a -> Js_json.t) -> string -> string -> Node.Fs.encoding -> unit
+
 (** goldenSpec and sampleServerSpec *)  
 
 val decodeIntWithResult : Js_json.t -> (int, string) Belt.Result.t


### PR DESCRIPTION
This allows for encoding other that utf8 to be used. The list of encoding include those supported by Node.Fs.fileReadSync